### PR TITLE
corrected the name of the keyword used in the examples

### DIFF
--- a/selenium/gologin.py
+++ b/selenium/gologin.py
@@ -25,7 +25,7 @@ class GoLogin(object):
         self.credentials_enable_service = options.get('credentials_enable_service')
 
         home = str(pathlib.Path.home())
-        self.executablePath = options.get('executablePath', os.path.join(home, '.gologin/browser/orbita-browser/chrome'))
+        self.executablePath = options.get('executable_path', os.path.join(home, '.gologin/browser/orbita-browser/chrome'))
         print('executablePath', self.executablePath)
         if self.extra_params:
             print('extra_params', self.extra_params)


### PR DESCRIPTION
corrected the name of the keyword used in the examples
you pass pythonic-way the name executable_path, but in the class you try to get executablePath