### PR TITLE
Fix cookies with tempdir override, stopAndCommit used incorrect

### DIFF
--- a/gologin.js
+++ b/gologin.js
@@ -46,19 +46,18 @@ class GoLogin {
     this.browserChecker = new BrowserChecker();
     this.uploadCookiesToServer = options.uploadCookiesToServer || false;
     this.writeCookesFromServer = options.writeCookesFromServer || true;
-    this.cookiesFilePath = path.join(os.tmpdir(), `gologin_profile_${this.profile_id}`, 'Default', 'Cookies');
     this.remote_debugging_port = options.remote_debugging_port || 0;
     this.timezone = options.timezone;
 
     if (options.tmpdir) {
       this.tmpdir = options.tmpdir;
-      this.cookiesFilePath = path.join(this.tmpdir, `gologin_profile_${this.profile_id}`, 'Default', 'Cookies');
       if (!fs.existsSync(this.tmpdir)) {
         debug('making tmpdir', this.tmpdir);
         shell.mkdir('-p', this.tmpdir);
       }
     }
 
+    this.cookiesFilePath = path.join(this.tmpdir, `gologin_profile_${this.profile_id}`, 'Default', 'Cookies');
     this.profile_zip_path = path.join(this.tmpdir, `gologin_${this.profile_id}.zip`);
     debug('INIT GOLOGIN', this.profile_id);
   }

--- a/gologin.js
+++ b/gologin.js
@@ -52,6 +52,7 @@ class GoLogin {
 
     if (options.tmpdir) {
       this.tmpdir = options.tmpdir;
+      this.cookiesFilePath = path.join(this.tmpdir, `gologin_profile_${this.profile_id}`, 'Default', 'Cookies');
       if (!fs.existsSync(this.tmpdir)) {
         debug('making tmpdir', this.tmpdir);
         shell.mkdir('-p', this.tmpdir);
@@ -66,6 +67,7 @@ class GoLogin {
 
   async setProfileId(profile_id) {
     this.profile_id = profile_id;
+    this.cookiesFilePath = path.join(this.tmpdir, `gologin_profile_${this.profile_id}`, 'Default', 'Cookies');
     this.profile_zip_path = path.join(this.tmpdir, `gologin_${this.profile_id}.zip`);
   }
 
@@ -697,7 +699,7 @@ class GoLogin {
     await rimraf(path.join(this.tmpdir, `gologin_${this.profile_id}_upload.zip`));
   }
 
-  async stopAndCommit(options, local= false) {
+  async stopAndCommit(options, local = false) {
     if (this.is_stopping) {
       return true;
     }
@@ -1049,12 +1051,12 @@ class GoLogin {
       return this.stopRemote();
     }
 
-    await this.stopAndCommit(false, {});
+    await this.stopAndCommit({ posting: false }, false);
   }
 
   async stopLocal(options) {
-    const opts = options || {posting: false};
-    await this.stopAndCommit(true, opts.posting);
+    const opts = options || { posting: false };
+    await this.stopAndCommit(options, true);
   }
 
   async waitDebuggingUrl(delay_ms, try_count=0) {


### PR DESCRIPTION
1. Cookies directory is stored in os.tempdir() always, sqlite can't open not existing file
https://github.com/gologinapp/gologin/blob/5bc67f23ee1845628f8284c95a4f4e337eb16cb9/cookies-manager.js#L76

2. stopAndCommit has swapped argument order. `posting` will be always false in stopLocal(options)
https://github.com/gologinapp/gologin/blob/5bc67f23ee1845628f8284c95a4f4e337eb16cb9/gologin.js#L700

- [ ] TODO: Bump package version