### PR TITLE
Fix rmdir non-exists error

### DIFF
--- a/browser-checker.js
+++ b/browser-checker.js
@@ -94,7 +94,10 @@ class BrowserChecker {
   }
 
   async downloadBrowser() {
-    await this.deleteOldArchives(true);
+    if (fs.existsSync(this.#browserPath)) {
+      await this.deleteOldArchives(true);
+    }
+    
     await mkdir(this.#browserPath, { recursive: true });
 
     const pathStr = path.join(this.#browserPath, BROWSER_ARCHIVE_NAME);

--- a/browser-checker.js
+++ b/browser-checker.js
@@ -270,10 +270,13 @@ class BrowserChecker {
       });
       return Promise.all(promises);
     } else {
-      await rmdir(path.join(this.#browserPath, 'orbita-browser'), { recursive: true });
+      const targetPath = path.join(this.#browserPath, 'orbita-browser');
+      if (fs.existsSync(targetPath)) {
+        await rmdir(targetPath, { recursive: true });
+      }
       await this.copyDir(
         path.join(this.#browserPath, EXTRACTED_FOLDER, 'orbita-browser'),
-        path.join(this.#browserPath, 'orbita-browser')
+        targetPath
       );
     }
   }

--- a/browser-user-data-manager.js
+++ b/browser-user-data-manager.js
@@ -57,13 +57,13 @@ class BrowserUserDataManager {
     const files = await readdir(browserFontsPath);
     const fontsToDownload = fontsList.filter(font => !files.includes(font));
 
-    let promises = fontsToDownload.map(font => request.get(FONTS_URL + font, {
-      maxAttempts: 3,
-      retryDelay: 2000,
-      timeout: 10 * 1000,
-    })
-      .pipe(createWriteStream(path.join(browserFontsPath, font)))
-    );
+    let promises = fontsToDownload.map(font => new Promise(resolve => {
+      request.get(FONTS_URL + font, {
+        maxAttempts: 3,
+        retryDelay: 2000,
+        timeout: 10 * 1000,
+      }).pipe(createWriteStream(path.join(browserFontsPath, font))).on("finish", resolve);
+    }));
 
     if (promises.length) {
       await Promise.all(promises);


### PR DESCRIPTION
The first time using `gologin`, `rmdir` will raise an error because the folder does not exist.