### PR TITLE
fix: no need to multiply device memory

### DIFF
--- a/src/gologin.js
+++ b/src/gologin.js
@@ -1073,7 +1073,7 @@ export class GoLogin {
       deviceMemory = 1;
     }
 
-    navigator.deviceMemory = deviceMemory*1024;
+    navigator.deviceMemory = deviceMemory;
     webGLMetadata.mode = webGLMetadata.mode === 'noise' ? 'mask' : 'off';
 
     const json = {


### PR DESCRIPTION
When creating new profile server returns error that device memory should be one of 1,2,4,6,8