### PR TITLE
fillBasedOnIp fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gologin",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "A high-level API to control Orbita browser over GoLogin API",
   "main": "./src/gologin.js",
   "repository": {

--- a/src/gologin.js
+++ b/src/gologin.js
@@ -295,6 +295,12 @@ export class GoLogin {
       audioOutputs: preferences.mediaDevices.audioOutputs,
     };
 
+    preferences.webRtc = {
+      ...preferences.webRtc,
+      fill_based_on_ip: !!get(preferences, 'webRTC.fillBasedOnIp'),
+      local_ip_masking: !!get(preferences, 'webRTC.local_ip_masking'),
+    };
+
     return preferences;
   }
 


### PR DESCRIPTION
fixed display of profile geolocation, by latitude and longitude specified in the profile, when the fillBasedOnIp setting is disabled