### PR TITLE
Setting bookmarks file path in setProfileId method

### DIFF
--- a/src/gologin.js
+++ b/src/gologin.js
@@ -82,6 +82,7 @@ export class GoLogin {
     this.profile_id = profile_id;
     this.cookiesFilePath = join(this.tmpdir, `gologin_profile_${this.profile_id}`, 'Default', 'Network', 'Cookies');
     this.profile_zip_path = join(this.tmpdir, `gologin_${this.profile_id}.zip`);
+    this.bookmarksFilePath = join(this.tmpdir, `gologin_profile_${this.profile_id}`, 'Default', 'Bookmarks');
   }
 
   async getToken(username, password) {


### PR DESCRIPTION
When we specify profile_id in setProfileId and not in the GoLogin constructor, this throws an error.
[Error: ENOENT: no such file or directory, open '/tmp/gologin_profile_undefined/Default/Bookmarks'] { errno: -2, code: 'ENOENT', syscall: 'open', path: '/tmp/gologin_profile_undefined/Default/Bookmarks' }